### PR TITLE
Fix memory leaks

### DIFF
--- a/endpoints-control/src/main/java/com/google/api/control/aggregator/CheckAggregationOptions.java
+++ b/endpoints-control/src/main/java/com/google/api/control/aggregator/CheckAggregationOptions.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2023 Uwe Trottmann
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +21,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Ticker;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.RemovalListener;
-import com.google.common.cache.RemovalNotification;
 
-import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
@@ -42,13 +40,7 @@ public class CheckAggregationOptions {
    */
   public static final int DEFAULT_RESPONSE_EXPIRATION_MILLIS = 4000;
 
-  /**
-   * The default flush cache entry interval.
-   */
-  public static final int DEFAULT_FLUSH_CACHE_ENTRY_INTERVAL_MILLIS = 2000;
-
   private final int numEntries;
-  private final int flushCacheEntryIntervalMillis;
   private final int expirationMillis;
 
   /**
@@ -58,21 +50,13 @@ public class CheckAggregationOptions {
    *            is the maximum number of cache entries that can be kept in the
    *            aggregation cache. The cache is disabled if this value is
    *            negative.
-   * @param flushCacheEntryIntervalMillis
-   *            the maximum interval before an aggregated check request is
-   *            flushed to the server. The cache entry is deleted after the
-   *            flush
    * @param expirationMillis
    *            is the maximum interval in milliseconds before a cached check
-   *            response is invalidated. This value should be greater than
-   *            {@code flushCacheEntryIntervalMillis}. If not, it is ignored,
-   *            and a value of {@code flushCacheEntryIntervalMillis} is used
-   *            instead.
+   *            response is invalidated.
    */
-  public CheckAggregationOptions(int numEntries, int flushCacheEntryIntervalMillis, int expirationMillis) {
+  public CheckAggregationOptions(int numEntries, int expirationMillis) {
     this.numEntries = numEntries;
-    this.flushCacheEntryIntervalMillis = flushCacheEntryIntervalMillis;
-    this.expirationMillis = Math.max(expirationMillis, flushCacheEntryIntervalMillis + 1);
+    this.expirationMillis = expirationMillis;
   }
 
   /**
@@ -81,7 +65,7 @@ public class CheckAggregationOptions {
    * Creates an instance initialized with the default values.
    */
   public CheckAggregationOptions() {
-    this(DEFAULT_NUM_ENTRIES, DEFAULT_FLUSH_CACHE_ENTRY_INTERVAL_MILLIS, DEFAULT_RESPONSE_EXPIRATION_MILLIS);
+    this(DEFAULT_NUM_ENTRIES, DEFAULT_RESPONSE_EXPIRATION_MILLIS);
   }
 
   /**
@@ -93,17 +77,8 @@ public class CheckAggregationOptions {
   }
 
   /**
-   * @return the maximum interval before aggregated report requests are
-   *         flushed to the server
-   */
-  public int getFlushCacheEntryIntervalMillis() {
-    return flushCacheEntryIntervalMillis;
-  }
-
-  /**
    * @return the maximum interval before a cached check response should be
-   *         deleted. This value will not be greater than
-   *         {@link #getFlushCacheEntryIntervalMillis()}
+   *         deleted.
    */
   public int getExpirationMillis() {
     return expirationMillis;
@@ -115,45 +90,29 @@ public class CheckAggregationOptions {
    * @param <T>
    *            the type of the instance being cached
    *
-   * @param out
-   *            a concurrent {@code Deque} to which previously cached items
-   *            are added as they expire
    * @return a {@link Cache} corresponding to this instance's values or
    *         {@code null} unless {@link #numEntries} is positive.
    */
   @Nullable
-  public <T> Cache<String, T> createCache(ConcurrentLinkedDeque<T> out) {
-    return createCache(out, Ticker.systemTicker());
+  public <T> Cache<String, T> createCache() {
+    return createCache(Ticker.systemTicker());
   }
 
   /**
    * Creates a {@link Cache} configured by this instance.
    *
-   * @param <T>
-   *            the type of the value stored in the Cache
-   * @param out
-   *            a concurrent {@code Deque} to which the cached values are
-   *            added as they are removed from the cache
-   * @param ticker
-   *            the time source used to determine expiration
+   * @param <T>    the type of the value stored in the Cache
+   * @param ticker the time source used to determine expiration
    * @return a {@link Cache} corresponding to this instance's values or
-   *         {@code null} unless {@code #numEntries} is positive.
+   * {@code null} unless {@code #numEntries} is positive.
    */
   @Nullable
-  public <T> Cache<String, T> createCache(final ConcurrentLinkedDeque<T> out, Ticker ticker) {
-    Preconditions.checkNotNull(out, "The out deque cannot be null");
+  public <T> Cache<String, T> createCache(Ticker ticker) {
     Preconditions.checkNotNull(ticker, "The ticker cannot be null");
     if (numEntries <= 0) {
       return null;
     }
-    final RemovalListener<String, T> listener = new RemovalListener<String, T>() {
-      @Override
-      public void onRemoval(RemovalNotification<String, T> notification) {
-        out.addFirst(notification.getValue());
-      }
-    };
-    CacheBuilder<String, T> b = CacheBuilder.newBuilder().maximumSize(numEntries).ticker(ticker)
-        .removalListener(listener);
+    CacheBuilder<Object, Object> b = CacheBuilder.newBuilder().maximumSize(numEntries).ticker(ticker);
     if (expirationMillis >= 0) {
       b.expireAfterWrite(expirationMillis, TimeUnit.MILLISECONDS);
     }

--- a/endpoints-control/src/main/java/com/google/api/control/aggregator/CheckRequestAggregator.java
+++ b/endpoints-control/src/main/java/com/google/api/control/aggregator/CheckRequestAggregator.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2023 Uwe Trottmann
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +17,6 @@
 
 package com.google.api.control.aggregator;
 
-import com.google.api.MetricDescriptor.MetricKind;
 import com.google.api.servicecontrol.v1.CheckRequest;
 import com.google.api.servicecontrol.v1.CheckResponse;
 import com.google.api.servicecontrol.v1.MetricValue;
@@ -27,35 +27,25 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.base.Ticker;
 import com.google.common.cache.Cache;
-import com.google.common.collect.Lists;
-import com.google.common.flogger.FluentLogger;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.concurrent.ConcurrentLinkedDeque;
+
 import javax.annotation.Nullable;
+import java.nio.charset.StandardCharsets;
 
 /**
- * Caches and aggregates {@link CheckRequest}s.
+ * Caches {@link CheckRequest}s.
  */
 public class CheckRequestAggregator {
   /**
-   * The flush interval returned by {@link #getFlushIntervalMillis() } when an instance is
+   * The flush interval returned by {@link #getExpirationMillis() } when an instance is
    * configured to be non-caching.
    */
   public static final int NON_CACHING = -1;
 
-  private static final int NANOS_PER_MILLI = 1000000;
-  private static final CheckRequest[] NO_REQUESTS = new CheckRequest[] {};
-  private static final FluentLogger log = FluentLogger.forEnclosingClass();
-
   private final String serviceName;
   private final CheckAggregationOptions options;
-  private final Map<String, MetricKind> kinds;
-  private final ConcurrentLinkedDeque<CachedItem> out;
   private final Cache<String, CachedItem> cache;
   private final Ticker ticker;
 
@@ -64,33 +54,18 @@ public class CheckRequestAggregator {
    *
    * @param serviceName the service whose {@code CheckRequest}s are being aggregated
    * @param options configures this instance's caching behavior
-   * @param kinds specifies the {@link MetricKind} for specific metric names
    * @param ticker the time source used to determine expiration. When not specified, this defaults
    *        to {@link Ticker#systemTicker()}
    */
   public CheckRequestAggregator(String serviceName, CheckAggregationOptions options,
-      @Nullable Map<String, MetricKind> kinds, @Nullable Ticker ticker) {
+                                @Nullable Ticker ticker) {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(serviceName),
         "service name cannot be empty");
     Preconditions.checkNotNull(options, "options must be non-null");
-    this.out = new ConcurrentLinkedDeque<CachedItem>();
     this.ticker = ticker == null ? Ticker.systemTicker() : ticker;
-    this.cache = options.createCache(out, this.ticker);
+    this.cache = options.createCache(this.ticker);
     this.serviceName = serviceName;
     this.options = options;
-    this.kinds = kinds;
-  }
-
-  /**
-   * Constructor.
-   *
-   * @param serviceName the service whose {@code CheckRequest}s are being aggregated
-   * @param options configures this instances caching behavior
-   * @param kinds specifies the {@link MetricKind} for specific metric names
-   */
-  public CheckRequestAggregator(String serviceName, CheckAggregationOptions options,
-      @Nullable Map<String, MetricKind> kinds) {
-    this(serviceName, options, kinds, Ticker.systemTicker());
   }
 
   /**
@@ -100,13 +75,13 @@ public class CheckRequestAggregator {
    * @param options configures this instances caching behavior
    */
   public CheckRequestAggregator(String serviceName, CheckAggregationOptions options) {
-    this(serviceName, options, null);
+    this(serviceName, options, Ticker.systemTicker());
   }
 
   /**
-   * @return the interval in milliseconds between calls to {@link #flush}
+   * @return See {@link CheckAggregationOptions#getExpirationMillis()}.
    */
-  public int getFlushIntervalMillis() {
+  public int getExpirationMillis() {
     if (cache == null) {
       return NON_CACHING;
     } else {
@@ -132,36 +107,6 @@ public class CheckRequestAggregator {
     }
     synchronized (cache) {
       cache.invalidateAll();
-      out.clear();
-    }
-  }
-
-  /**
-   * Flushes this instance's cache.
-   *
-   * The instance's driver should call the this method every {@link #getFlushIntervalMillis()}
-   * milliseconds, and send the results to the check service.
-   *
-   * @return CheckRequest[] containing the CheckRequests that were pending
-   */
-  public CheckRequest[] flush() {
-    if (cache == null) {
-      return NO_REQUESTS;
-    }
-
-    // Thread safety - the current thread cleans up the cache, which may add multiple cached
-    // aggregated operations to the output deque.
-    synchronized (cache) {
-      cache.cleanUp();
-      ArrayList<CheckRequest> reqs = Lists.newArrayList();
-      for (CachedItem item : out) {
-        CheckRequest req = item.extractRequest();
-        if (req != null) {
-          reqs.add(req);
-        }
-      }
-      out.clear();
-      return reqs.toArray(new CheckRequest[reqs.size()]);
     }
   }
 
@@ -181,7 +126,7 @@ public class CheckRequestAggregator {
     synchronized (cache) {
       CachedItem item = cache.getIfPresent(signature);
       if (item == null) {
-        cache.put(signature, new CachedItem(resp, req, kinds, now, quotaScale));
+        cache.put(signature, new CachedItem(resp, now, quotaScale));
       } else {
         item.lastCheckTimestamp = now;
         item.response = resp;
@@ -230,37 +175,7 @@ public class CheckRequestAggregator {
     if (item == null) {
       return null; // signal caller to send the response
     } else {
-      return handleCachedResponse(req, item);
-    }
-  }
-
-  private boolean isCurrent(CachedItem item) {
-    long age = ticker.read() - item.lastCheckTimestamp;
-    return age < (options.getFlushCacheEntryIntervalMillis() * NANOS_PER_MILLI);
-  }
-
-  private CheckResponse handleCachedResponse(CheckRequest req, CachedItem item) {
-    if (item.response.getCheckErrorsCount() > 0) {
-      if (isCurrent(item)) {
-        return item.response;
-      }
-
-      // Not current
-      item.lastCheckTimestamp = ticker.read();
-      return null; // signal the caller to make a new check request
-    } else {
-      if (isCurrent(item)) {
-        return item.response;
-      }
-      item.updateRequest(req, kinds);
-      if (item.isFlushing) {
-        log.atWarning().log("latest check request has not completed");
-      }
-
-      // Not current
-      item.isFlushing = true;
-      item.lastCheckTimestamp = ticker.read();
-      return null; // signal the caller to make a new check request
+      return item.response;
     }
   }
 
@@ -302,42 +217,18 @@ public class CheckRequestAggregator {
     long lastCheckTimestamp;
     int quotaScale;
     CheckResponse response;
-    private final String serviceName;
-
-    private OperationAggregator aggregator;
 
     /**
      * @param response the cached {@code CheckResponse}
-     * @param request caused {@code response}
-     * @param kinds the kinds of metrics
      * @param lastCheckTimestamp the last time the {@code CheckRequest} for tracked by this item was
      *        checked
      * @param quotaScale WIP, used to track quota
      */
-    CachedItem(CheckResponse response, CheckRequest request, Map<String, MetricKind> kinds,
-        long lastCheckTimestamp, int quotaScale) {
+    CachedItem(CheckResponse response, long lastCheckTimestamp, int quotaScale) {
       this.response = response;
-      this.serviceName = request.getServiceName();
       this.lastCheckTimestamp = lastCheckTimestamp;
       this.quotaScale = quotaScale;
-      this.aggregator = new OperationAggregator(request.getOperation(), kinds);
     }
 
-    public synchronized void updateRequest(CheckRequest req, Map<String, MetricKind> kinds) {
-      if (this.aggregator == null) {
-        this.aggregator = new OperationAggregator(req.getOperation(), kinds);
-      } else {
-        aggregator.add(req.getOperation());
-      }
-    }
-
-    public synchronized CheckRequest extractRequest() {
-      if (this.aggregator == null) {
-        return null;
-      }
-      Operation op = this.aggregator.asOperation();
-      this.aggregator = null;
-      return CheckRequest.newBuilder().setServiceName(this.serviceName).setOperation(op).build();
-    }
   }
 }


### PR DESCRIPTION
The check call of `Client` appears to be leaking memory.

Turns out the `out` Queue of `CheckRequestAggregator` is filled with expired cache entries. But as it is never flushed (which would be pointless anyhow as check requests are already sent before a request) as the scheduler background thread does not work on App Engine Standard this will leak a `CheckResponse` for each user making a request.

This removes the `out` queue completely from `CheckRequestAggregator` which never really aggregated anything, but only cached check request responses. Now it will only cache check request responses.